### PR TITLE
Fix: Module "buffer" has no exported member 'Blob'

### DIFF
--- a/types/superagent/index.d.ts
+++ b/types/superagent/index.d.ts
@@ -20,7 +20,6 @@ import * as fs from "fs";
 import * as http from "http";
 import * as stream from "stream";
 import * as cookiejar from "cookiejar";
-import { Blob } from "buffer";
 
 type CallbackHandler = (err: any, res: request.Response) => void;
 


### PR DESCRIPTION
In an Ionic/Angular environment this causes compilation issues, removing the line 23: `import { Blob } from "buffer";` problem was fixed by using core TypeScript Blob object.

- [x] tested in a personal project, fix works and code compiles
